### PR TITLE
Change the ReconfigurableSink to be an interface

### DIFF
--- a/cf_debug_server_suite_test.go
+++ b/cf_debug_server_suite_test.go
@@ -19,5 +19,5 @@ func TestCfDebugServer(t *testing.T) {
 var _ = SynchronizedBeforeSuite(func() []byte {
 	return nil
 }, func(encodedBuiltArtifacts []byte) {
-	address = fmt.Sprintf("127.0.0.1:%d", 10000+GinkgoParallelNode())
+	address = fmt.Sprintf("127.0.0.1:%d", 10000+GinkgoParallelProcess())
 })

--- a/server.go
+++ b/server.go
@@ -21,6 +21,11 @@ type DebugServerConfig struct {
 	DebugAddress string `json:"debug_address"`
 }
 
+type ReconfigurableSinkInterface interface {
+	SetMinLevel(level lager.LogLevel)
+	GetMinLevel() lager.LogLevel
+}
+
 func AddFlags(flags *flag.FlagSet) {
 	flags.String(
 		DebugFlag,
@@ -38,11 +43,11 @@ func DebugAddress(flags *flag.FlagSet) string {
 	return dbgFlag.Value.String()
 }
 
-func Runner(address string, sink *lager.ReconfigurableSink) ifrit.Runner {
+func Runner(address string, sink ReconfigurableSinkInterface) ifrit.Runner {
 	return http_server.New(address, Handler(sink))
 }
 
-func Run(address string, sink *lager.ReconfigurableSink) (ifrit.Process, error) {
+func Run(address string, sink ReconfigurableSinkInterface) (ifrit.Process, error) {
 	p := ifrit.Invoke(Runner(address, sink))
 	select {
 	case <-p.Ready():
@@ -52,7 +57,7 @@ func Run(address string, sink *lager.ReconfigurableSink) (ifrit.Process, error) 
 	return p, nil
 }
 
-func Handler(sink *lager.ReconfigurableSink) http.Handler {
+func Handler(sink ReconfigurableSinkInterface) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
 	mux.Handle("/debug/pprof/trace", http.HandlerFunc(pprof.Trace))

--- a/server.go
+++ b/server.go
@@ -23,7 +23,6 @@ type DebugServerConfig struct {
 
 type ReconfigurableSinkInterface interface {
 	SetMinLevel(level lager.LogLevel)
-	GetMinLevel() lager.LogLevel
 }
 
 func AddFlags(flags *flag.FlagSet) {


### PR DESCRIPTION
We can now accept other logging solutions (slog) as an argument for greater flexibility

- [x] Read the [Contributing document](../blob/-/.github/CONTRIBUTING.md).

Summary
---------------
By using an interface, we can now create other `ResconfigurableSinks` that meet the needs of other logging solutions.
For example, https://github.com/cloudfoundry/lager/blob/main/reconfigurable_sink.go can now be extended to a `SlogReconfigurableSink`  which could then use [slog](https://pkg.go.dev/log/slog) instead.


Backward Compatibility
---------------
Breaking Change? **No**
